### PR TITLE
[show] Delete old ECR images

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 module "docker-image" {
 	source = "terraform-aws-modules/lambda/aws//modules/docker-build"
+	version = "~> 2.29"
 
 	create_ecr_repo = true
 	ecr_repo = var.function_name
@@ -9,7 +10,7 @@ module "docker-image" {
 
 module "lambda" {
 	source = "terraform-aws-modules/lambda/aws"
-	version = "~> 2.17"
+	version = "~> 2.29"
 
 	create_package = false
 	environment_variables = var.environment_variables

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,20 @@ module "docker-image" {
 
 	create_ecr_repo = true
 	ecr_repo = var.function_name
+	ecr_repo_lifecycle_policy = jsonencode({
+		rules = [
+			{
+				action = { type = "expire" }
+				description = "Keep only the last 2 images"
+				rulePriority = 1
+				selection = {
+					countNumber = 2
+					countType = "imageCountMoreThan"
+					tagStatus = "any"
+				}
+			}
+		]
+	})
 	image_tag = var.function_version
 	source_path = var.docker_build
 }


### PR DESCRIPTION
# Overview
By default, only keep the last 2 docker images in AWS ECR by deleting any older Docker Image. 